### PR TITLE
Update FluentUI packages to version 4.11.7

### DIFF
--- a/src/Blazor.WebAssembly/Blazor.WebAssembly.csproj
+++ b/src/Blazor.WebAssembly/Blazor.WebAssembly.csproj
@@ -24,8 +24,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.3" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.3" />
-    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.11.6" />
-    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.11.6" />
+    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.11.7" />
+    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.11.7" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updated the `Microsoft.FluentUI.AspNetCore.Components` and `Microsoft.FluentUI.AspNetCore.Components.Icons` packages from version `4.11.6` to `4.11.7` in the
Blazor WebAssembly project file (`Blazor.WebAssembly.csproj`).