### PR TITLE
Update .gitignore to exclude new blob storage paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -413,3 +413,4 @@ __azurite_db_blob_extent__.json
 __azurite_db_blob__.json
 __blobstorage__/c824c11f-d0d0-43a9-8e89-15b95a6144f0
 __blobstorage__/a358f272-4fb2-4a07-a19a-6bd068169fa7
+/src/CoverageReport


### PR DESCRIPTION
Added paths to ignore for the following:
- `__blobstorage__/8151a5e3-a34c-4aaa-bd98-6ce83e8dbd54`
- `__azurite_db_blob_extent__.json`
- `__azurite_db_blob__.json`
- `__blobstorage__/c824c11f-d0d0-43a9-8e89-15b95a6144f0`
- `__blobstorage__/a358f272-4fb2-4a07-a19a-6bd068169fa7`
- `/src/CoverageReport`