### PR TITLE
Update project settings and add unit tests for SignalR

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,6 @@
     "azureFunctions.projectLanguage": "C#",
     "azureFunctions.projectRuntime": "~4",
     "debug.internalConsoleOptions": "neverOpen",
-    "azureFunctions.preDeployTask": "publish (functions)"
+    "azureFunctions.preDeployTask": "publish (functions)",
+    "azureTerraform.terminal": "integrated"
 }

--- a/src/Azure.Functions.Tests/Azure.Functions.Tests.csproj
+++ b/src/Azure.Functions.Tests/Azure.Functions.Tests.csproj
@@ -1,0 +1,32 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Azure.Functions\Azure.Functions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/src/Azure.Functions.Tests/SignalRFunctionsUnitTests.cs
+++ b/src/Azure.Functions.Tests/SignalRFunctionsUnitTests.cs
@@ -1,0 +1,66 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.SignalRService;
+using Microsoft.Azure.WebJobs.Extensions.Timers;
+using NSubstitute;
+using System.Reflection;
+
+namespace Azure.Functions.Tests
+{
+    public class SignalRFunctionsUnitTests
+    {
+        [Fact]
+        public void Negotiate_ReturnsConnectionInfo()
+        {
+            // Arrange
+            var mockHttpRequest = Substitute.For<HttpRequest>();
+            var connectionInfo = new SignalRConnectionInfo { Url = "http://localhost", AccessToken = "token" };
+
+            // Act
+            var result = SignalRFunctions.Negotiate(mockHttpRequest, connectionInfo);
+
+            // Assert
+            Assert.Equal(connectionInfo, result);
+        }
+
+        [Fact]
+        public async Task Broadcast_SendsMessage()
+        {
+            // Arrange
+            var mockCollector = Substitute.For<IAsyncCollector<SignalRMessage>>();
+            var timerInfo = new TimerInfo(null, new ScheduleStatus(), false);
+
+            // Act
+            await SignalRFunctions.Broadcast(timerInfo, mockCollector);
+
+            // Assert
+            await mockCollector.Received(1).AddAsync(Arg.Is<SignalRMessage>(m => m.Target == "ReceiveCounter" && (int)m.Arguments[0] > 0));
+        }
+
+        [Fact]
+        public void Update_UpdatesCounter()
+        {
+            // Arrange
+            var invocationContext = new InvocationContext
+            {
+                Arguments = [10]
+            };
+
+            // Act
+            SignalRFunctions.Update(invocationContext);
+
+            // Assert
+            // Use reflection to access the private static field 'counter'
+            var counterField = typeof(SignalRFunctions).GetField("counter", BindingFlags.Static | BindingFlags.NonPublic);
+            if (counterField != null)
+            {
+                var counterValue = counterField.GetValue(null) as int?;
+                Assert.Equal(10, counterValue);
+            }
+            else
+            {
+                Assert.Fail("Counter field not found.");
+            }
+        }
+    }
+}

--- a/src/Web.sln
+++ b/src/Web.sln
@@ -18,6 +18,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Bicep", "Bicep", "{62D6D839
 		..\infra\bicep\main.bicep = ..\infra\bicep\main.bicep
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Projects", "Projects", "{02EA681E-C7D8-13C7-8484-4AC65E1B71E8}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{35EF3588-0679-4AC5-94AE-08BEBCD50495}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Functions.Tests", "Azure.Functions.Tests\Azure.Functions.Tests.csproj", "{1FFFDCC7-42C6-4F6E-A456-341EAAC7D20D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -32,12 +38,19 @@ Global
 		{41453017-19ED-43EF-88AC-6608787F7ED2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{41453017-19ED-43EF-88AC-6608787F7ED2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{41453017-19ED-43EF-88AC-6608787F7ED2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1FFFDCC7-42C6-4F6E-A456-341EAAC7D20D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1FFFDCC7-42C6-4F6E-A456-341EAAC7D20D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1FFFDCC7-42C6-4F6E-A456-341EAAC7D20D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1FFFDCC7-42C6-4F6E-A456-341EAAC7D20D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
+		{09D305EB-4B87-446E-95D1-E3996522DAD4} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{41453017-19ED-43EF-88AC-6608787F7ED2} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{62D6D839-508B-4BCB-81EF-4B249A6AED0A} = {769C0D9A-4CE9-4390-94B2-C2546227B4AD}
+		{1FFFDCC7-42C6-4F6E-A456-341EAAC7D20D} = {35EF3588-0679-4AC5-94AE-08BEBCD50495}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {DB4B6C07-F1F9-4A70-A65C-26B1A3EFFCFE}


### PR DESCRIPTION
- Updated `settings.json` to include `azureTerraform.terminal` and corrected `azureFunctions.preDeployTask`.
- Modified `Web.sln` to add "Projects" and "Tests" sections, including "Azure.Functions.Tests".
- Created/modified `Azure.Functions.Tests.csproj` with project settings and package references.
- Added unit tests in `SignalRFunctionsUnitTests.cs` for `Negotiate`, `Broadcast`, and `Update` methods using NSubstitute.